### PR TITLE
fix #6 (plugin fails to load)

### DIFF
--- a/lib/asciidoctor/interdoc_reftext/processor.rb
+++ b/lib/asciidoctor/interdoc_reftext/processor.rb
@@ -63,9 +63,8 @@ module Asciidoctor::InterdocReftext
     # @param resolver_class [#new] the {Resolver} class to use.
     # @param resolver_opts [Hash<Symbol, Object>] options to be passed into
     #   the resolver_class's initializer (see {Resolver#initialize}).
-    def initialize(resolver_class: Resolver, **resolver_opts)
+    def initialize(resolver_opts)
       super
-      @resolver_class = resolver_class
       @resolver_opts = resolver_opts
 
       # Monkey-patch Asciidoctor::Inline unless already patched.
@@ -82,7 +81,7 @@ module Asciidoctor::InterdocReftext
 
     # @param document [Asciidoctor::Document] the document to process.
     def process(document)
-      resolver = @resolver_class.new(document, **@resolver_opts)
+      resolver = Resolver.new(document, **@resolver_opts)
       document.instance_variable_set(RESOLVER_VAR_NAME, resolver)
       nil
     end

--- a/lib/asciidoctor/interdoc_reftext/version.rb
+++ b/lib/asciidoctor/interdoc_reftext/version.rb
@@ -3,6 +3,6 @@
 module Asciidoctor
   module InterdocReftext
     # Version of the asciidoctor-interdoc-reftext gem.
-    VERSION = '0.5.2'
+    VERSION = '0.5.3'
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asciidoctor-interdoc-reftext",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Asciidoctor extension providing implicit (automatic) reference text (label) for inter-document cross references",
   "author": "Jakub Jirutka <jakub@jirutka.cz>",
   "license": "MIT",


### PR DESCRIPTION
This plugin failed to load under Asciidoctor 2.0.22 due to a difference between the signature of the initialize method on the base `Asciidoctor::Extensions::TreeProcessor` class and the implemented initialize method in `lib/asciidoctor/interdoc_reftext/processor.rb`. This commit modifies the function signature, and makes it so the Processor class is now directly instantiated instead of by a reference passed to the initialize method.